### PR TITLE
Fix Numpy-2.0

### DIFF
--- a/scripts/python/pyDtOO/dtClusteredSingletonState.py
+++ b/scripts/python/pyDtOO/dtClusteredSingletonState.py
@@ -349,7 +349,7 @@ class dtClusteredSingletonState:
     """
     rStr = '__unknownDataType__'
     if isinstance(value,float):
-      rStr = "{:s}".format(repr(value))
+      rStr = np.format_float_scientific(value)
     elif isinstance(value,int):
       rStr = "{:s}".format(repr(value))
     elif isinstance(value,str):
@@ -360,7 +360,7 @@ class dtClusteredSingletonState:
       valueAsStr = np.array2string(
         valueAsArr,
         formatter = {
-          'float_kind':lambda valueAsArr: "%s" % repr(valueAsArr)
+          'float_kind': np.format_float_scientific
         }
       )
       #

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -234,6 +234,22 @@ set_tests_properties(
 )
 set_property(TEST pyDtOO-dtField PROPERTY LABELS base-test)
 
+#
+# write-runData
+#
+add_test(
+  NAME write-runData
+  COMMAND ${Python_EXECUTABLE} "build.py"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/write-runData
+)
+set_tests_properties(
+  write-runData
+  PROPERTIES
+    ENVIRONMENT 
+    "PYTHONPATH=${CMAKE_SOURCE_DIR}/scripts/python:$ENV{PYTHONPATH};"
+)
+set_property(TEST write-runData PROPERTY LABELS base-test)
+
 file(GLOB sources_list LIST_DIRECTORIES true "${CMAKE_SOURCE_DIR}/test/*")
 foreach(dirPath ${sources_list})
     IF(IS_DIRECTORY ${dirPath})

--- a/test/write-runData/build.py
+++ b/test/write-runData/build.py
@@ -1,0 +1,41 @@
+#------------------------------------------------------------------------------
+#  dtOO < design tool Object-Oriented >
+#    
+#    Copyright (C) 2024 A. Tismer.
+#------------------------------------------------------------------------------
+#License
+#    This file is part of dtOO.
+#
+#    dtOO is distributed in the hope that it will be useful, but WITHOUT
+#    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#    FITNESS FOR A PARTICULAR PURPOSE.  See the LICENSE.txt file in the
+#    dtOO root directory for more details.
+#
+#    You should have received a copy of the License along with dtOO.
+#
+#------------------------------------------------------------------------------
+
+import sys
+import os
+os.environ["OSLO_LOCK_PATH"] = "./runLock"
+import numpy as np
+from pyDtOO import dtClusteredSingletonState
+
+defObj = [1.0, 2.0]
+defFit = 1.0
+
+s = dtClusteredSingletonState(defObj=defObj, defFit=defFit)
+
+print("defObj")
+if np.array_equal( s.objective(), defObj):
+  print("-> OK")
+else:
+  print("-> FAIL")
+  sys.exit(-1)
+
+print("defFit")
+if s.fitness() == defFit:
+  print("-> OK")
+else:
+  print("-> FAIL")
+  sys.exit(-1)


### PR DESCRIPTION
Newer Versions of Numpy write float number in a different way compared to 
e.g. Version 1.19. As an example, the `objective` file in `runData` is then not correctly 
formatted.

`objective` data of the test `write-runData` in different Numpy versions:

Numpy 2.0
```txt
np.float64(1.0) np.float64(2.0)
```
and in Numpy 1.24
```txt
1.0 2.0
```
