### PR TITLE
Fix dtValueField for NumPy 2.4 and newer

### DIFF
--- a/demo/hydFoilOpt/build.py
+++ b/demo/hydFoilOpt/build.py
@@ -1241,8 +1241,12 @@ class hydFoil:
     # Integrate pressure and velocity over inlet and outlet; calculate the
     # sum of those energies to get the difference in head
     #
-    e_i = (p_i.IntValueQ() / g + U_i.IntMagSquareQ() / 2.0 / g)
-    e_o = (p_o.IntValueQ() / g + U_o.IntMagSquareQ() / 2.0 / g)
+    e_i = np.asarray(
+      p_i.IntValueQ() / g + U_i.IntMagSquareQ() / 2.0 / g
+    ).item()
+    e_o = np.asarray(
+      p_o.IntValueQ() / g + U_o.IntMagSquareQ() / 2.0 / g
+    ).item()
     Q_i = np.abs(U_i.IntQ())
     dHMean = (e_i + e_o) / Q_i
    

--- a/scripts/python/pyDtOO/dtValueField.py
+++ b/scripts/python/pyDtOO/dtValueField.py
@@ -78,16 +78,16 @@ class dtValueField:
     ret = numpy.zeros( self.vDim_ )
     logging.info('vDim = %d', self.vDim_)
     for i in range(0, self.vDim_):
-      ret[i] = numpy.dot( self.value_[:,i], self.q_[:] )
+      ret[i] = numpy.dot( self.value_[:,i], self.q_.ravel() )
     return ret
 
   def IntMagQ(self):
     return numpy.dot( 
-      numpy.sqrt(numpy.sum( self.value_[:,:]**2., axis=1 )), self.q_[:] 
+      numpy.sqrt(numpy.sum( self.value_[:,:]**2., axis=1 )), self.q_.ravel()
     )
 
   def IntMagSquareQ(self):
-    return numpy.dot( numpy.sum( self.value_[:,:]**2., axis=1 ), self.q_[:] )
+    return numpy.dot( numpy.sum( self.value_[:,:]**2., axis=1 ), self.q_.ravel() )
   
   def IntValueA(self):
     ret = numpy.zeros( self.vDim_ )


### PR DESCRIPTION
Implicit conversion of non-zero-dimensional arrays to scalars is deprecated since NumPy 1.25 and raises errors since 2.4: https://numpy.org/doc/stable/release/2.4.0-notes.html#expired-deprecations

dtValueField.q_ has shape (N, 1):

https://github.com/ihs-ustutt/dtOO/blob/4d5bd84bc11ede0f20cb1365196fe75a90da71cf/scripts/python/pyDtOO/dtValueField.py#L42

such that the dot product returns arrays with shape (1,). Cannot be assigned to scalar.