### PR TITLE
Fix build with OpenVolumeMesh 3.x

### DIFF
--- a/src/libraryKernel/meshEngine/dtOVMTypedef.h
+++ b/src/libraryKernel/meshEngine/dtOVMTypedef.h
@@ -20,7 +20,7 @@ License
 
 #include <dtOOTypeDef.h>
 
-#include <OpenVolumeMesh/Core/OpenVolumeMeshProperty.hh>
+#include <OpenVolumeMesh/Core/PropertyPtr.hh>
 #include <OpenVolumeMesh/Mesh/PolyhedralMesh.hh>
 
 namespace dtOO {


### PR DESCRIPTION
The header ```OpenVolumeMesh/Core/OpenVolumeMeshProperty.hh``` was removed in OpenVolumeMesh's commit [629e059](https://github.com/nTopology/OpenVolumeMesh/commit/629e0598c6bae6776e349de010a0de8f57d6d04f)
This PR includes the new header.

Maybe dependencies should be pinned, as suggested in the unmerged [PR](https://github.com/ihs-ustutt/dtOO-ThirdParty/pull/20). However, that also applies to rapidjson and muparser:

https://github.com/ihs-ustutt/dtOO-ThirdParty/blob/d73f60057922741143f2809d8db170986ce392d7/buildDep#L444-L450

https://github.com/ihs-ustutt/dtOO-ThirdParty/blob/d73f60057922741143f2809d8db170986ce392d7/buildDep#L545-L549

