### PR TITLE
Fix interTransMesh

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,7 +128,7 @@ DTOO_ADD_DOCTEST(
 )
 DTOO_ADD_DOCTEST(
   interTransMesh
-  "${CMAKE_SOURCE_DIR}/scripts/python/pyDtOO/dtClusteredSingletonState.py"
+  "${CMAKE_SOURCE_DIR}/test/interTransMesh/interTransMesh.py"
   ""
 )
 DTOO_ADD_DOCTEST(floatAtt "floatAtt.py" "/floatAtt")

--- a/tools/libdtOOPythonSWIG/dtOOPythonSWIG.i
+++ b/tools/libdtOOPythonSWIG/dtOOPythonSWIG.i
@@ -368,6 +368,7 @@ using namespace dtOO;
 #include <attributionHeaven/pointGeometryDist.h>
 #include <attributionHeaven/geometryGeometryDist.h>
 #include <attributionHeaven/curveCurveDist.h>
+#include <minFloatAttr.h>
 #include <gslMinFloatAttr.h>
 #include <gslGradMinFloatAttr.h>
 %}
@@ -1265,6 +1266,7 @@ namespace std {
 %include attributionHeaven/pointGeometryDist.h
 %include attributionHeaven/geometryGeometryDist.h
 %include attributionHeaven/curveCurveDist.h
+%include minFloatAttr.h
 %include gslMinFloatAttr.h
 namespace dtOO {
   %extend gslMinFloatAttr {


### PR DESCRIPTION
  - `interTransMesh` was never called, because of a wrong path in
    CMakeLists.txt

  - Fix missing header in SWIG interface
